### PR TITLE
fix: change variable name in `bs.sidebar:create`

### DIFF
--- a/docs/_templates/changelog/v3.0.0.md
+++ b/docs/_templates/changelog/v3.0.0.md
@@ -23,3 +23,8 @@
 ### `🎯 bs.hitbox`
 
 - <abbr title="New Features">✨</abbr> **[#285](https://github.com/mcbookshelf/Bookshelf/pull/285)** - Introduced a `#bs.hitbox:is_sized` tag for improved hitbox management.
+
+
+### `📰 bs.sidebar`
+
+- <abbr title="Bug fix">🐛</abbr> **[#301](https://github.com/mcbookshelf/Bookshelf/pull/301)** Fixed the issue where `bs.sidebar:create` was not functioning correctly.

--- a/modules/bs.sidebar/data/bs.sidebar/function/create/create.mcfunction
+++ b/modules/bs.sidebar/data/bs.sidebar/function/create/create.mcfunction
@@ -34,16 +34,16 @@ execute unless score #s bs.ctx matches 1 run return run function #bs.log:error {
 }
 
 # check that the contents have between 1 and 15 entries
-execute store result score #l bs.ctx if data storage bs:ctx _.contents[]
-execute unless score #l bs.ctx matches 1..15 run return run function #bs.log:error { \
+execute store result score #s bs.ctx if data storage bs:ctx _.contents[]
+execute unless score #s bs.ctx matches 1..15 run return run function #bs.log:error { \
   namespace: "bs.sidebar", \
   path: "#bs.sidebar:create", \
   tag: "create", \
-  message: '[{"text":"The contents must have between 1 and 15 lines (","color":"red"},{"score":{"name":"#l","objective":"bs.ctx"}},{"text":" given)."}]', \
+  message: '[{"text":"The contents must have between 1 and 15 lines (","color":"red"},{"score":{"name":"#s","objective":"bs.ctx"}},{"text":" given)."}]', \
 }
 
 # start the recursion to create each line abort if a line failed
 execute as B5-0-0-0-2 run function bs.sidebar:create/recurse/start with storage bs:ctx _
 data remove entity @s CustomName
-execute if score #l bs.ctx = #i bs.ctx run return 1
+execute if score #s bs.ctx = #i bs.ctx run return 1
 return run function bs.sidebar:create/recurse/abort with storage bs:ctx _

--- a/modules/bs.sidebar/data/bs.sidebar/tags/function/create.json
+++ b/modules/bs.sidebar/data/bs.sidebar/tags/function/create.json
@@ -5,6 +5,9 @@
     "authors": [
       "Aksiome"
     ],
+    "contributors": [
+      "runoshun"
+    ],
     "created": {
       "date": "2023/08/18",
       "minecraft_version": "23w32a"


### PR DESCRIPTION
### Description
Fixed the issue where `bs.sidebar:create` was not functioning correctly.

### Related Issues
none

However, as far as I could confirm, it seemed that bs.sidebar/create was not functioning at all in either version 1.21.3 or 1.21.4.It appears that the variable name (a placeholder player name for the score) is conflicting with `bs.sidebar:recurse/next`.

### Additional Notes
-

## Tasks to complete before merging

- [x] I agree to release my contribution under the [MPL v2 License](http://mozilla.org/MPL/2.0/).
- [ ] My pull request is associated with an existing issue.
- [x] I have updated the [changelog](https://github.com/mcbookshelf/Bookshelf/blob/master/docs/CHANGELOG.md) to reflect my contribution.
- [ ] If this pull request adds or modifies a feature:
  - [ ] I have documented my changes in the `/docs` folder.
  - [ ] I have thoroughly tested my changes. See [testing guidelines](https://docs.mcbookshelf.dev/en/latest/contribute/debug.html#unit-tests).
