### PR TITLE
🐛 fix: location-based loot tables outside the overworld

### DIFF
--- a/docs/_templates/changelog/v3.0.0.md
+++ b/docs/_templates/changelog/v3.0.0.md
@@ -23,10 +23,18 @@
 ### `🧱 bs.block`
 
 - <abbr title="New Features">✨</abbr> **[#279](https://github.com/mcbookshelf/Bookshelf/issues/279)** - Added a `#bs.block:play_block_sound` tag for playing block sounds.
+- <abbr title="Bug fix">🐛</abbr> **[#320](https://github.com/mcbookshelf/Bookshelf/issues/320)** - Fixed functions that were unusable outside the Overworld.
+
+
+### `🧱 bs.environment`
+
+- <abbr title="Bug fix">🐛</abbr> **[#320](https://github.com/mcbookshelf/Bookshelf/issues/320)** - Fixed functions that were unusable outside the Overworld.
+
 
 ### `🌱 bs.generate`
 
 - <abbr title="Breaking Changes">⚠️</abbr> **[#296](https://github.com/mcbookshelf/Bookshelf/issues/296)** Renamed the `bs.generate` module to `bs.generation`.
+
 
 ### `🌱 bs.generation`
 
@@ -35,15 +43,19 @@
   - <abbr title="Breaking Changes">⚠️</abbr> **[#296](https://github.com/mcbookshelf/Bookshelf/issues/296)** Renamed the `bs.generate:shape_2d` function to `bs.generation:gen_shape_2d`.
   - <abbr title="Breaking Changes">⚠️</abbr> **[#296](https://github.com/mcbookshelf/Bookshelf/issues/296)** Renamed the `bs.generate:simplex_shape_2d` function to `bs.generation:gen_simplex_shape_2d`.
 
+
 ### `🎯 bs.hitbox`
 
 - <abbr title="Breaking Changes">⚠️</abbr> **[#297](https://github.com/mcbookshelf/Bookshelf/issues/297)** - Renamed block tag `is_composite` to `not_full_cube` for better clarity.
 - <abbr title="New Features">✨</abbr> **[#285](https://github.com/mcbookshelf/Bookshelf/pull/285)** - Introduced a `#bs.hitbox:is_sized` tag for improved hitbox management.
 - <abbr title="New Features">✨</abbr> **[#299](https://github.com/mcbookshelf/Bookshelf/pull/299)** - Block tag `#bs.hitbox:can_pass_through` was moved from the move module and is now properly documented.
+- <abbr title="Bug fix">🐛</abbr> **[#320](https://github.com/mcbookshelf/Bookshelf/issues/320)** - Fixed functions that were unusable outside the Overworld.
+
 
 ### `📰 bs.sidebar`
 
 - <abbr title="Bug fix">🐛</abbr> **[#301](https://github.com/mcbookshelf/Bookshelf/pull/301)** Fixed the issue where `bs.sidebar:create` was not functioning correctly.
+
 
 ### `👀 bs.view`
 

--- a/meta/manifest.json
+++ b/meta/manifest.json
@@ -975,7 +975,7 @@
         },
         {
           "id": "#bs.hitbox:intangible",
-          "documentation": "https://docs.mcbookshelf.dev/en/latest/modules/hitbox.html#intangible",
+          "documentation": "https://docs.mcbookshelf.dev/en/latest/modules/hitbox.html#blocks",
           "authors": [
             "Aksiome"
           ],
@@ -990,7 +990,7 @@
         },
         {
           "id": "#bs.hitbox:intangible",
-          "documentation": "https://docs.mcbookshelf.dev/en/latest/modules/hitbox.html#blocks",
+          "documentation": "https://docs.mcbookshelf.dev/en/latest/modules/hitbox.html#intangible",
           "authors": [
             "Aksiome"
           ],

--- a/modules/bs.block/data/bs.block/function/__load__.mcfunction
+++ b/modules/bs.block/data/bs.block/function/__load__.mcfunction
@@ -17,6 +17,7 @@ forceload add -30000000 1600
 setblock -30000000 0 1606 minecraft:decorated_pot
 execute unless entity B5-0-0-0-1 run summon minecraft:marker -30000000 0 1600 {UUID:[I;181,0,0,1],Tags:["bs.entity","bs.persistent","smithed.entity","smithed.strict"]}
 execute unless entity B5-0-0-0-2 run summon minecraft:text_display -30000000 0 1600 {UUID:[I;181,0,0,2],Tags:["bs.entity","bs.persistent","smithed.entity","smithed.strict"],view_range:0f,alignment:"center"}
+execute unless entity B5-0-0-0-3 run summon minecraft:item_display -30000000 0 1600 {UUID:[I;181,0,0,3],Tags:["bs.entity","bs.persistent","smithed.entity","smithed.strict"],view_range:0f}
 
 scoreboard objectives add bs.ctx dummy [{"text":"BS ","color":"dark_gray"},{"text":"Context","color":"aqua"}]
 scoreboard objectives add bs.data dummy [{"text":"BS ","color":"dark_gray"},{"text":"Data","color":"aqua"}]

--- a/modules/bs.block/data/bs.block/function/__unload__.mcfunction
+++ b/modules/bs.block/data/bs.block/function/__unload__.mcfunction
@@ -15,6 +15,7 @@
 
 kill B5-0-0-0-1
 kill B5-0-0-0-2
+kill B5-0-0-0-3
 setblock -30000000 0 1606 minecraft:air
 forceload remove -30000000 1600
 

--- a/modules/bs.block/data/bs.block/function/fill/strategy/set_random.mcfunction
+++ b/modules/bs.block/data/bs.block/function/fill/strategy/set_random.mcfunction
@@ -14,7 +14,7 @@
 # ------------------------------------------------------------------------------------------------------------
 
 data remove storage bs:data block._.block
-$loot replace block -30000000 0 1606 container.0 loot $(entries)
+$execute in minecraft:overworld run loot replace block -30000000 0 1606 container.0 loot $(entries)
 data modify storage bs:data block._ merge from block -30000000 0 1606 item.components."minecraft:custom_data"
 
 execute unless data storage bs:data block._.block run return run function bs.block:fill/strategy/set_type

--- a/modules/bs.block/data/bs.block/function/get/get_block.mcfunction
+++ b/modules/bs.block/data/bs.block/function/get/get_block.mcfunction
@@ -14,6 +14,6 @@
 # ------------------------------------------------------------------------------------------------------------
 
 data remove storage bs:out block
-loot replace block -30000000 0 1606 container.0 loot bs.block:get/get_block
-data modify storage bs:out block set from block -30000000 0 1606 item.components."minecraft:custom_data"
+loot replace entity B5-0-0-0-3 container.0 loot bs.block:get/get_block
+data modify storage bs:out block set from entity B5-0-0-0-3 item.components."minecraft:custom_data"
 data modify storage bs:out block.nbt set from block ~ ~ ~ {}

--- a/modules/bs.block/data/bs.block/function/get/get_type.mcfunction
+++ b/modules/bs.block/data/bs.block/function/get/get_type.mcfunction
@@ -14,5 +14,5 @@
 # ------------------------------------------------------------------------------------------------------------
 
 data remove storage bs:out block
-loot replace block -30000000 0 1606 container.0 loot bs.block:get/get_type
-data modify storage bs:out block set from block -30000000 0 1606 item.components."minecraft:custom_data"
+loot replace entity B5-0-0-0-3 container.0 loot bs.block:get/get_type
+data modify storage bs:out block set from entity B5-0-0-0-3 item.components."minecraft:custom_data"

--- a/modules/bs.block/data/bs.block/function/transform/merge_properties/merge_properties.mcfunction
+++ b/modules/bs.block/data/bs.block/function/transform/merge_properties/merge_properties.mcfunction
@@ -17,6 +17,6 @@ execute if data storage bs:out block{group:0} run return 0
 
 $data modify storage bs:ctx _ set value {i:$(properties)}
 function bs.block:transform/lookup_group with storage bs:out block
-loot replace block -30000000 0 1606 container.0 loot bs.block:get/get_block
-data modify storage bs:ctx _.p set from block -30000000 0 1606 item.components."minecraft:custom_data".properties
+loot replace entity B5-0-0-0-3 container.0 loot bs.block:get/get_block
+data modify storage bs:ctx _.p set from entity B5-0-0-0-3 item.components."minecraft:custom_data".properties
 function bs.block:transform/merge_properties/recurse/next with storage bs:ctx _.i[-1]

--- a/modules/bs.environment/data/bs.environment/function/__load__.mcfunction
+++ b/modules/bs.environment/data/bs.environment/function/__load__.mcfunction
@@ -14,7 +14,7 @@
 # ------------------------------------------------------------------------------------------------------------
 
 forceload add -30000000 1600
-setblock -30000000 0 1606 minecraft:decorated_pot
+execute unless entity B5-0-0-0-3 run summon minecraft:item_display -30000000 0 1600 {UUID:[I;181,0,0,3],Tags:["bs.entity","bs.persistent","smithed.entity","smithed.strict"],view_range:0f}
 
 scoreboard objectives add bs.const dummy [{"text":"BS ","color":"dark_gray"},{"text":"Constants","color":"aqua"}]
 scoreboard objectives add bs.ctx dummy [{"text":"BS ","color":"dark_gray"},{"text":"Context","color":"aqua"}]

--- a/modules/bs.environment/data/bs.environment/function/__unload__.mcfunction
+++ b/modules/bs.environment/data/bs.environment/function/__unload__.mcfunction
@@ -13,7 +13,7 @@
 # For more details, refer to the MPL v2.0.
 # ------------------------------------------------------------------------------------------------------------
 
-setblock -30000000 0 1606 minecraft:air
+kill B5-0-0-0-3
 forceload remove -30000000 1600
 
 data remove storage bs:out environment

--- a/modules/bs.environment/data/bs.environment/function/get/biome/get_biome.mcfunction
+++ b/modules/bs.environment/data/bs.environment/function/get/biome/get_biome.mcfunction
@@ -14,5 +14,5 @@
 # ------------------------------------------------------------------------------------------------------------
 
 data remove storage bs:out environment.get_biome
-loot replace block -30000000 0 1606 container.0 loot bs.environment:get/get_biome
-data modify storage bs:out environment.get_biome set from block -30000000 0 1606 item.components."minecraft:custom_data"
+loot replace entity B5-0-0-0-3 container.0 loot bs.environment:get/get_biome
+data modify storage bs:out environment.get_biome set from entity B5-0-0-0-3 item.components."minecraft:custom_data"

--- a/modules/bs.environment/data/bs.environment/function/get/temperature/get_temperature.mcfunction
+++ b/modules/bs.environment/data/bs.environment/function/get/temperature/get_temperature.mcfunction
@@ -13,7 +13,7 @@
 # For more details, refer to the MPL v2.0.
 # ------------------------------------------------------------------------------------------------------------
 
-loot replace block -30000000 0 1606 container.0 loot bs.environment:get/get_biome
-execute store result score #t bs.ctx run data get block -30000000 0 1606 item.components."minecraft:custom_data".temperature
+loot replace entity B5-0-0-0-3 container.0 loot bs.environment:get/get_biome
+execute store result score #t bs.ctx run data get entity B5-0-0-0-3 item.components."minecraft:custom_data".temperature
 execute store result storage bs:ctx y double .00000001 summon minecraft:marker run function bs.environment:get/temperature/variation
 $execute store result score $environment.get_temperature bs.out run return run data get storage bs:ctx y $(scale)

--- a/modules/bs.generation/data/bs.generation/function/__load__.mcfunction
+++ b/modules/bs.generation/data/bs.generation/function/__load__.mcfunction
@@ -14,7 +14,6 @@
 # ------------------------------------------------------------------------------------------------------------
 
 forceload add -30000000 1600
-setblock -30000000 0 1606 minecraft:decorated_pot
 execute unless entity B5-0-0-0-1 run summon minecraft:marker -30000000 0 1600 {UUID:[I;181,0,0,1],Tags:["bs.entity","bs.persistent","smithed.entity","smithed.strict"]}
 
 scoreboard objectives add bs.ctx dummy [{"text":"BS ","color":"dark_gray"},{"text":"Context","color":"aqua"}]

--- a/modules/bs.hitbox/data/bs.hitbox/function/__load__.mcfunction
+++ b/modules/bs.hitbox/data/bs.hitbox/function/__load__.mcfunction
@@ -14,7 +14,7 @@
 # ------------------------------------------------------------------------------------------------------------
 
 forceload add -30000000 1600
-setblock -30000000 0 1606 minecraft:decorated_pot
+execute unless entity B5-0-0-0-3 run summon minecraft:item_display -30000000 0 1600 {UUID:[I;181,0,0,3],Tags:["bs.entity","bs.persistent","smithed.entity","smithed.strict"],view_range:0f}
 
 scoreboard objectives add bs.const dummy [{"text":"BS ","color":"dark_gray"},{"text":"Constants","color":"aqua"}]
 scoreboard objectives add bs.ctx dummy [{"text":"BS ","color":"dark_gray"},{"text":"Context","color":"aqua"}]

--- a/modules/bs.hitbox/data/bs.hitbox/function/__unload__.mcfunction
+++ b/modules/bs.hitbox/data/bs.hitbox/function/__unload__.mcfunction
@@ -13,7 +13,7 @@
 # For more details, refer to the MPL v2.0.
 # ------------------------------------------------------------------------------------------------------------
 
-setblock -30000000 0 1606 minecraft:air
+kill B5-0-0-0-3
 forceload remove -30000000 1600
 
 scoreboard objectives remove bs.const

--- a/modules/bs.hitbox/data/bs.hitbox/function/get_block/get_block.mcfunction
+++ b/modules/bs.hitbox/data/bs.hitbox/function/get_block/get_block.mcfunction
@@ -16,6 +16,6 @@
 execute unless block ~ ~ ~ #bs.hitbox:not_full_cube run \
   return run data modify storage bs:out hitbox set value {shape:[[0.0,0.0,0.0,16.0,16.0,16.0]]}
 
-loot replace block -30000000 0 1606 container.0 loot bs.hitbox:get/get_block
-data modify storage bs:out hitbox set from block -30000000 0 1606 item.components."minecraft:custom_data"
+loot replace entity B5-0-0-0-3 container.0 loot bs.hitbox:get/get_block
+data modify storage bs:out hitbox set from entity B5-0-0-0-3 item.components."minecraft:custom_data"
 execute if block ~ ~ ~ #bs.hitbox:has_offset summon minecraft:marker run function bs.hitbox:get_block/offset/get

--- a/modules/bs.random/data/bs.random/function/weighted_choice/run.mcfunction
+++ b/modules/bs.random/data/bs.random/function/weighted_choice/run.mcfunction
@@ -13,7 +13,7 @@
 # For more details, refer to the MPL v2.0.
 # ------------------------------------------------------------------------------------------------------------
 
-$loot replace block -30000000 0 1606 container.0 loot $(_)
+$execute in minecraft:overworld run loot replace block -30000000 0 1606 container.0 loot $(_)
 data modify storage bs:ctx _ set from block -30000000 0 1606 item.components."minecraft:custom_data"
 data modify storage bs:out random.weighted_choice set from storage bs:ctx _.v
 return run data get storage bs:ctx _.i


### PR DESCRIPTION
### Description
Fix location based loot tables

### Related Issues
<!-- Link to the issue(s) this PR resolves, if applicable. -->
- closes #320

### Additional Notes
<!-- Any extra context or information, if necessary. -->

## Tasks to complete before merging

- [x] I agree to release my contribution under the [MPL v2 License](http://mozilla.org/MPL/2.0/).
- [x] My pull request is associated with an existing issue.
- [ ] I have updated the [changelog](https://github.com/mcbookshelf/Bookshelf/blob/master/docs/CHANGELOG.md) to reflect my contribution.
- [ ] If this pull request adds or modifies a feature:
  - [ ] I have documented my changes in the `/docs` folder.
  - [ ] I have thoroughly tested my changes. See [testing guidelines](https://docs.mcbookshelf.dev/en/latest/contribute/debug.html#unit-tests).
