### PR TITLE
🐛 fix(bs.view): use correct hit normal in at_block_placement

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -4313,8 +4313,8 @@
             "minecraft_version": "1.20.4"
           },
           "updated": {
-            "date": "2024/05/09",
-            "minecraft_version": "1.20.6"
+            "date": "2025/05/01",
+            "minecraft_version": "1.21.5"
           }
         },
         {

--- a/docs/changelog/v3.0.1.md
+++ b/docs/changelog/v3.0.1.md
@@ -20,3 +20,8 @@
 ### `🔠 bs.string`
 
 - <abbr title="Bug Fixes">🐛</abbr> **[#423](https://github.com/mcbookshelf/bookshelf/pull/423)** - Fix module tag incorrectly set to default, now set to runtime to ensure the module is properly included in bundles.
+
+
+### `👀 bs.view`
+
+- <abbr title="Bug Fixes">🐛</abbr> **[#424](https://github.com/mcbookshelf/bookshelf/issues/424)** - Fix `#bs.view:at_block_placement` that was incorrectly using hit normal data from the previous call instead of the current one.

--- a/modules/bs.view/data/bs.view/function/block_placement/at_block_placement.mcfunction
+++ b/modules/bs.view/data/bs.view/function/block_placement/at_block_placement.mcfunction
@@ -15,6 +15,6 @@
 
 # run the raycast at the entity eyes
 tag @s add bs.view.this
-$data modify storage bs:data raycast.on_targeted_block set value 'function bs.view:block_placement/compute {run:\'$(run)\'}'
+$data modify storage bs:data view.block_placement.run set value '$(run)'
 execute at @s anchored eyes positioned ^ ^ ^ run function bs.raycast:run
 tag @s remove bs.view.this

--- a/modules/bs.view/data/bs.view/function/block_placement/displace.mcfunction
+++ b/modules/bs.view/data/bs.view/function/block_placement/displace.mcfunction
@@ -13,4 +13,8 @@
 # For more details, refer to the MPL v2.0.
 # ------------------------------------------------------------------------------------------------------------
 
-$tp @s ~$(x) ~$(y) ~$(z)
+data modify storage bs:data view.block_placement.x set from storage bs:lambda raycast.hit_normal[0]
+data modify storage bs:data view.block_placement.y set from storage bs:lambda raycast.hit_normal[1]
+data modify storage bs:data view.block_placement.z set from storage bs:lambda raycast.hit_normal[2]
+
+execute as @n[tag=bs.view.this,sort=arbitrary] run function bs.view:block_placement/run with storage bs:data view.block_placement

--- a/modules/bs.view/data/bs.view/function/block_placement/run.mcfunction
+++ b/modules/bs.view/data/bs.view/function/block_placement/run.mcfunction
@@ -13,9 +13,4 @@
 # For more details, refer to the MPL v2.0.
 # ------------------------------------------------------------------------------------------------------------
 
-execute store result storage bs:ctx x int 1 run data get storage bs:out raycast.hit_normal[0]
-execute store result storage bs:ctx y int 1 run data get storage bs:out raycast.hit_normal[1]
-execute store result storage bs:ctx z int 1 run data get storage bs:out raycast.hit_normal[2]
-
-function bs.view:block_placement/displace with storage bs:ctx
-$execute at @s as @n[tag=bs.view.this,sort=arbitrary] run $(run)
+$execute positioned ~$(x) ~$(y) ~$(z) run $(run)

--- a/modules/bs.view/data/bs.view/function/block_placement/with.mcfunction
+++ b/modules/bs.view/data/bs.view/function/block_placement/with.mcfunction
@@ -20,5 +20,6 @@ data modify storage bs:data raycast set value { \
   hitbox_shape: "interaction", \
   ignored_blocks: "#bs.hitbox:intangible", \
   ignored_entities: "#bs.hitbox:intangible", \
+  on_targeted_block: "function bs.view:block_placement/displace", \
 }
 $data modify storage bs:data raycast merge value $(with)

--- a/modules/bs.view/data/bs.view/tags/function/at_block_placement.json
+++ b/modules/bs.view/data/bs.view/tags/function/at_block_placement.json
@@ -10,8 +10,8 @@
       "minecraft_version": "1.20.4"
     },
     "updated": {
-      "date": "2024/05/09",
-      "minecraft_version": "1.20.6"
+      "date": "2025/05/01",
+      "minecraft_version": "1.21.5"
     }
   },
   "values": [

--- a/modules/bs.view/data/bs.view/test/at_block_placement.mcfunction
+++ b/modules/bs.view/data/bs.view/test/at_block_placement.mcfunction
@@ -18,3 +18,9 @@ fill ~-1 ~ ~-1 ~1 ~1 ~1 minecraft:air
 setblock ~ ~1 ~1 minecraft:sponge
 function #bs.view:at_block_placement {run:"setblock ~ ~ ~ minecraft:bookshelf",with:{}}
 assert block ~ ~1 ~ minecraft:bookshelf
+setblock ~ ~1 ~ minecraft:air
+
+tp @s ~ ~ ~ 270 0
+setblock ~1 ~1 ~ minecraft:sponge
+function #bs.view:at_block_placement {run:"setblock ~ ~ ~ minecraft:bookshelf",with:{}}
+assert block ~ ~1 ~ minecraft:bookshelf


### PR DESCRIPTION
### Description
<!-- Briefly describe what this pull request does. -->

### Related Issues
- closes #424

### Additional Notes
<!-- Any extra context or information, if necessary. -->

## Tasks to complete before merging

- [x] I agree to release my contribution under the [MPL v2 License](http://mozilla.org/MPL/2.0/).
- [x] My pull request is associated with an existing issue.
- [x] I have updated the [changelog](https://github.com/mcbookshelf/bookshelf/blob/master/docs/changelog/index.html) to reflect my contribution.
- [x] If this pull request adds or modifies a feature:
  - [ ] I have documented my changes in the `/docs` folder.
  - [x] I have updated the metadata of the feature. See [feature metadata](https://docs.mcbookshelf.dev/en/master/contribute/metadata.html#feature-metadata).
  - [x] I have thoroughly tested my changes. See [testing guidelines](https://docs.mcbookshelf.dev/en/master/contribute/debug.html#unit-tests).
