### PR TITLE
🐛 fix(bs.health): kill player when health drops below 0 unless in creative/spectator

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -841,7 +841,7 @@
             "minecraft_version": "1.20.2"
           },
           "updated": {
-            "date": "2025/04/14",
+            "date": "2025/05/01",
             "minecraft_version": "1.21.5"
           }
         },
@@ -901,7 +901,7 @@
             "minecraft_version": "1.20.2"
           },
           "updated": {
-            "date": "2025/04/14",
+            "date": "2025/05/01",
             "minecraft_version": "1.21.5"
           }
         },

--- a/docs/changelog/v3.0.1.md
+++ b/docs/changelog/v3.0.1.md
@@ -11,20 +11,21 @@
 ### `❤️ bs.health`
 
 - <abbr title="Bug Fix">🐛</abbr> **[#410](https://github.com/mcbookshelf/bookshelf/issues/410)** - Ensure player health updates consistently.
+- <abbr title="Bug Fix">🐛</abbr> **[#426](https://github.com/mcbookshelf/bookshelf/pull/426)** – Players are now correctly killed when their health drops below 0, unless they are in Creative or Spectator mode.
 
 
 ### `🧣 bs.spline`
 
-- <abbr title="Bug Fixes">🐛</abbr> **[#423](https://github.com/mcbookshelf/bookshelf/pull/423)** - Fix module tag incorrectly set to default, now set to runtime to ensure the module is properly included in bundles.
+- <abbr title="Bug Fix">🐛</abbr> **[#423](https://github.com/mcbookshelf/bookshelf/pull/423)** - Fix module tag incorrectly set to default, now set to runtime to ensure the module is properly included in bundles.
 - <abbr title="Bug Fix">🐛</abbr> **[#412](https://github.com/mcbookshelf/bookshelf/issues/412)** - Fix Hermite spline tangents to use absolute space instead of relative.
 - <abbr title="Enhancements">⚡</abbr> **[#409](https://github.com/mcbookshelf/bookshelf/issues/409)** - Improve performance of sampling and streaming functions.
 
 
 ### `🔠 bs.string`
 
-- <abbr title="Bug Fixes">🐛</abbr> **[#423](https://github.com/mcbookshelf/bookshelf/pull/423)** - Fix module tag incorrectly set to default, now set to runtime to ensure the module is properly included in bundles.
+- <abbr title="Bug Fix">🐛</abbr> **[#423](https://github.com/mcbookshelf/bookshelf/pull/423)** - Fix module tag incorrectly set to default, now set to runtime to ensure the module is properly included in bundles.
 
 
 ### `👀 bs.view`
 
-- <abbr title="Bug Fixes">🐛</abbr> **[#424](https://github.com/mcbookshelf/bookshelf/issues/424)** - Fix `#bs.view:at_block_placement` that was incorrectly using hit normal data from the previous call instead of the current one.
+- <abbr title="Bug Fix">🐛</abbr> **[#424](https://github.com/mcbookshelf/bookshelf/issues/424)** - Fix `#bs.view:at_block_placement` that was incorrectly using hit normal data from the previous call instead of the current one.

--- a/modules/bs.health/data/bs.health/function/utils/decrease_health.mcfunction
+++ b/modules/bs.health/data/bs.health/function/utils/decrease_health.mcfunction
@@ -14,6 +14,6 @@
 # ------------------------------------------------------------------------------------------------------------
 
 scoreboard players operation #h bs.ctx += @s bs.hmod
-execute if score #h bs.ctx matches ..0 run kill @s
+execute if score #h bs.ctx matches ..0 unless predicate {"condition":"minecraft:entity_properties","entity":"this","predicate":{"type_specific":{"type":"minecraft:player","gamemode":["creative","spectator"]}}} run kill @s
 execute store result storage bs:ctx y double 0.00001 run scoreboard players operation @s bs.hmod -= #m bs.ctx
 function bs.health:utils/apply_health with storage bs:ctx

--- a/modules/bs.health/data/bs.health/function/utils/increase_health.mcfunction
+++ b/modules/bs.health/data/bs.health/function/utils/increase_health.mcfunction
@@ -14,6 +14,7 @@
 # ------------------------------------------------------------------------------------------------------------
 
 # Give healing effect and revoke advancements that track when the effect is actually applied
+execute if predicate {"condition":"minecraft:entity_properties","entity":"this","predicate":{"effects":{"minecraft:instant_health":{"amplifier":{"min":29}}}}} run effect clear @s minecraft:instant_health
 effect give @s minecraft:instant_health 1 28 true
 scoreboard players operation @s bs.hval = #h bs.ctx
 advancement revoke @s only bs.health:on_heal

--- a/modules/bs.health/data/bs.health/tags/function/add_health.json
+++ b/modules/bs.health/data/bs.health/tags/function/add_health.json
@@ -10,7 +10,7 @@
       "minecraft_version": "1.20.2"
     },
     "updated": {
-      "date": "2025/04/14",
+      "date": "2025/05/01",
       "minecraft_version": "1.21.5"
     }
   },

--- a/modules/bs.health/data/bs.health/tags/function/set_health.json
+++ b/modules/bs.health/data/bs.health/tags/function/set_health.json
@@ -10,7 +10,7 @@
       "minecraft_version": "1.20.2"
     },
     "updated": {
-      "date": "2025/04/14",
+      "date": "2025/05/01",
       "minecraft_version": "1.21.5"
     }
   },


### PR DESCRIPTION
### Description
<!-- Briefly describe what this pull request does. -->

### Related Issues
<!-- Link to the issue(s) this PR resolves, if applicable. -->

### Additional Notes
<!-- Any extra context or information, if necessary. -->

## Tasks to complete before merging

- [x] I agree to release my contribution under the [MPL v2 License](http://mozilla.org/MPL/2.0/).
- [ ] My pull request is associated with an existing issue.
- [x] I have updated the [changelog](https://github.com/mcbookshelf/bookshelf/blob/master/docs/changelog/index.html) to reflect my contribution.
- [x] If this pull request adds or modifies a feature:
  - [ ] I have documented my changes in the `/docs` folder.
  - [x] I have updated the metadata of the feature. See [feature metadata](https://docs.mcbookshelf.dev/en/master/contribute/metadata.html#feature-metadata).
  - [x] I have thoroughly tested my changes. See [testing guidelines](https://docs.mcbookshelf.dev/en/master/contribute/debug.html#unit-tests).
