### PR TITLE
⚙️ ci: fix release process to work seamlessly with nightly builds

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -3,6 +3,9 @@ name: 🏷️ Nightly Release Build
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - data/versions.json
+      - docs/_static/switcher.json
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,10 @@ jobs:
           files: release/*.zip
       - name: Update Tag
         run: |
-          git fetch --tags
+          git fetch --tags --force
+          git push --delete origin latest || true
           git tag -f latest ${{ needs.check.outputs.release_tag }}
-          git push -f origin latest
+          git push origin latest
 
   publish:
     name: 🚀 PyPI Publish


### PR DESCRIPTION
### Description
Also ensure that rtd triggers a documentation build for the latest release by first deleting the latest tag and updating it with the new tag. This should guarantee that the latest tag points to the correct release, preventing it from referencing the old tag.

### Related Issues
<!-- Link to the issue(s) this PR resolves, if applicable. -->

### Additional Notes
<!-- Any extra context or information, if necessary. -->

## Tasks to complete before merging

- [x] I agree to release my contribution under the [MPL v2 License](http://mozilla.org/MPL/2.0/).
- [ ] My pull request is associated with an existing issue.
- [ ] I have updated the [changelog](https://github.com/mcbookshelf/bookshelf/blob/master/docs/changelog/index.html) to reflect my contribution.
- [ ] If this pull request adds or modifies a feature:
  - [ ] I have documented my changes in the `/docs` folder.
  - [ ] I have updated the metadata of the feature. See [feature metadata](https://docs.mcbookshelf.dev/en/master/contribute/metadata.html#feature-metadata).
  - [ ] I have thoroughly tested my changes. See [testing guidelines](https://docs.mcbookshelf.dev/en/master/contribute/debug.html#unit-tests).
