### PR TITLE
Add new block data

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1013,21 +1013,6 @@
         },
         {
           "id": "#bs.hitbox:intangible",
-          "documentation": "https://docs.mcbookshelf.dev/en/latest/modules/hitbox.html#entities",
-          "authors": [
-            "Aksiome"
-          ],
-          "created": {
-            "date": "2024/09/28",
-            "minecraft_version": "1.21"
-          },
-          "updated": {
-            "date": "2024/09/28",
-            "minecraft_version": "1.21"
-          }
-        },
-        {
-          "id": "#bs.hitbox:intangible",
           "documentation": "https://docs.mcbookshelf.dev/en/latest/modules/hitbox.html#blocks",
           "authors": [
             "Aksiome"
@@ -1039,6 +1024,21 @@
           "updated": {
             "date": "2025/03/10",
             "minecraft_version": "1.21.4"
+          }
+        },
+        {
+          "id": "#bs.hitbox:intangible",
+          "documentation": "https://docs.mcbookshelf.dev/en/latest/modules/hitbox.html#entities",
+          "authors": [
+            "Aksiome"
+          ],
+          "created": {
+            "date": "2024/09/28",
+            "minecraft_version": "1.21"
+          },
+          "updated": {
+            "date": "2024/09/28",
+            "minecraft_version": "1.21"
           }
         },
         {

--- a/docs/changelog/v3.1.0.md
+++ b/docs/changelog/v3.1.0.md
@@ -12,3 +12,7 @@
 ### `🔬 bs.dump`
 
 - <abbr title="Bug Fix">🐛</abbr> **[#441](https://github.com/mcbookshelf/bookshelf/issues/441)** - Fixed `#bs.dump:var` incorrectly appending `undefined` to output.
+
+### `🧱 bs.block`
+
+- <abbr title="Feature Improvement">✨</abbr> **[#450](https://github.com/mcbookshelf/bookshelf/issues/450)** - Added `blast_resistance`, `hardness`, `transparent`, `ignited_by_lava`, `stack_size`, and `map_color` to the block data. The return of `#bs.block:get_block` and `#bs.block:get_type` now includes these properties.

--- a/docs/modules/block.md
+++ b/docs/modules/block.md
@@ -192,6 +192,12 @@ Get all data related to the block at the current location, including its state a
       - {nbt}`string` **fall**: The sound played when a player falls on the block.
       - {nbt}`string` **place**: The sound played when a player places the block.
       - {nbt}`string` **step**: The sound played when a player steps on the block.
+    - {nbt}`float` **blast_resistance**: The blast resistance of the block.
+    - {nbt}`float` **hardness**: The hardness of the block.
+    - {nbt}`bool` **transparent**: Whether the block is transparent.
+    - {nbt}`bool` **ignited_by_lava**: Whether the block can be ignited by lava.
+    - {nbt}`int` **stack_size**: The stack size of the block.
+    - {nbt}`string` **map_color**: The map color of the block, in hexadecimal format.
   :::
 ```
 
@@ -229,6 +235,12 @@ Get the block type at the current location. Although states, NBTs, and propertie
       - {nbt}`string` **fall**: The sound played when a player falls on the block.
       - {nbt}`string` **place**: The sound played when a player places the block.
       - {nbt}`string` **step**: The sound played when a player steps on the block.
+    - {nbt}`float` **blast_resistance**: The blast resistance of the block.
+    - {nbt}`float` **hardness**: The hardness of the block.
+    - {nbt}`bool` **transparent**: Whether the block is transparent.
+    - {nbt}`bool` **ignited_by_lava**: Whether the block can be ignited by lava.
+    - {nbt}`int` **stack_size**: The stack size of the block.
+    - {nbt}`string` **map_color**: The map color of the block, in hexadecimal format.
   :::
 ```
 


### PR DESCRIPTION
### Description
Add new block data: blast resitance, hardness, transparent, ignited by lava, stack size and map color.

### Related Issues
closes #450.

### Additional Notes
<!-- Any extra context or information, if necessary. -->

## Tasks to complete before merging

- [x] I agree to release my contribution under the [MPL v2 License](http://mozilla.org/MPL/2.0/).
- [x] My pull request is associated with an existing issue.
- [x] I have updated the [changelog](https://github.com/mcbookshelf/bookshelf/blob/master/docs/changelog/index.html) to reflect my contribution.
- [x] If this pull request adds or modifies a feature:
  - [x] I have documented my changes in the `/docs` folder.
  - [ ] I have updated the metadata of the feature. See [feature metadata](https://docs.mcbookshelf.dev/en/master/contribute/metadata.html#feature-metadata).
  - [ ] I have thoroughly tested my changes. See [testing guidelines](https://docs.mcbookshelf.dev/en/master/contribute/debug.html#unit-tests).
