### PR TITLE
🐛 fix: ensure location-based loot tables run in the overworld

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -183,8 +183,8 @@
             "minecraft_version": "1.21"
           },
           "updated": {
-            "date": "2024/09/11",
-            "minecraft_version": "1.21"
+            "date": "2025/07/09",
+            "minecraft_version": "1.21.5"
           }
         },
         {
@@ -3302,8 +3302,8 @@
             "minecraft_version": "1.21"
           },
           "updated": {
-            "date": "2024/09/04",
-            "minecraft_version": "1.21"
+            "date": "2025/07/09",
+            "minecraft_version": "1.21.5"
           }
         },
         {

--- a/docs/changelog/v3.1.0.md
+++ b/docs/changelog/v3.1.0.md
@@ -5,6 +5,11 @@
 > *[Update Description]*
 
 
+### `🧱 bs.block`
+
+- <abbr title="Bug Fix">🐛</abbr> **[#469](https://github.com/mcbookshelf/bookshelf/issues/469)** - Fixed missing `execute in minecraft:overworld` when running location-based loot tables.
+
+
 ### `🔬 bs.dump`
 
 - <abbr title="Bug Fix">🐛</abbr> **[#441](https://github.com/mcbookshelf/bookshelf/issues/441)** - Fixed `#bs.dump:var` incorrectly appending `undefined` to output.
@@ -33,6 +38,7 @@
 ### `🎲 bs.random`
 
 - <abbr title="New Feature">✨</abbr>  **[#286](https://github.com/mcbookshelf/bookshelf/issues/286)** - Added support for **normal distribution** generation to `bs.random` module.
+- <abbr title="Bug Fix">🐛</abbr> **[#469](https://github.com/mcbookshelf/bookshelf/issues/469)** - Fixed missing `execute in minecraft:overworld` when running location-based loot tables.
 
 
 ### `🧣 bs.spline`

--- a/modules/bs.block/data/bs.block/function/fill/strategy/set_random.mcfunction
+++ b/modules/bs.block/data/bs.block/function/fill/strategy/set_random.mcfunction
@@ -15,7 +15,7 @@
 
 data remove storage bs:data block._.block
 $execute in minecraft:overworld run loot replace block -30000000 0 1606 container.0 loot $(entries)
-data modify storage bs:data block._ merge from block -30000000 0 1606 item.components."minecraft:custom_data"
+execute in minecraft:overworld run data modify storage bs:data block._ merge from block -30000000 0 1606 item.components."minecraft:custom_data"
 
 execute unless data storage bs:data block._.block run return run function bs.block:fill/strategy/set_type
 function bs.block:fill/strategy/set_block with storage bs:data block._

--- a/modules/bs.block/data/bs.block/tags/function/fill_random.json
+++ b/modules/bs.block/data/bs.block/tags/function/fill_random.json
@@ -13,8 +13,8 @@
       "minecraft_version": "1.21"
     },
     "updated": {
-      "date": "2024/09/11",
-      "minecraft_version": "1.21"
+      "date": "2025/07/09",
+      "minecraft_version": "1.21.5"
     }
   },
   "values": [

--- a/modules/bs.random/data/bs.random/function/weighted_choice/run.mcfunction
+++ b/modules/bs.random/data/bs.random/function/weighted_choice/run.mcfunction
@@ -14,6 +14,6 @@
 # ------------------------------------------------------------------------------------------------------------
 
 $execute in minecraft:overworld run loot replace block -30000000 0 1606 container.0 loot $(_)
-data modify storage bs:ctx _ set from block -30000000 0 1606 item.components."minecraft:custom_data"
+execute in minecraft:overworld run data modify storage bs:ctx _ set from block -30000000 0 1606 item.components."minecraft:custom_data"
 data modify storage bs:out random.weighted_choice set from storage bs:ctx _.v
 return run data get storage bs:ctx _.i

--- a/modules/bs.random/data/bs.random/tags/function/weighted_choice.json
+++ b/modules/bs.random/data/bs.random/tags/function/weighted_choice.json
@@ -10,8 +10,8 @@
       "minecraft_version": "1.21"
     },
     "updated": {
-      "date": "2024/09/04",
-      "minecraft_version": "1.21"
+      "date": "2025/07/09",
+      "minecraft_version": "1.21.5"
     }
   },
   "values": [


### PR DESCRIPTION
### Description
<!-- Briefly describe what this pull request does. -->

### Related Issues
- fix #469 

### Additional Notes
<!-- Any extra context or information, if necessary. -->

## Tasks to complete before merging

- [x] I agree to release my contribution under the [MPL v2 License](http://mozilla.org/MPL/2.0/).
- [x] My pull request is associated with an existing issue.
- [x] I have updated the [changelog](https://github.com/mcbookshelf/bookshelf/blob/master/docs/changelog/index.html) to reflect my contribution.
- [x] If this pull request adds or modifies a feature:
  - [x] I have documented my changes in the `/docs` folder.
  - [x] I have updated the metadata of the feature. See [feature metadata](https://docs.mcbookshelf.dev/en/master/contribute/metadata.html#feature-metadata).
  - [x] I have thoroughly tested my changes. See [testing guidelines](https://docs.mcbookshelf.dev/en/master/contribute/debug.html#unit-tests).
